### PR TITLE
Use OSM-ID and expose all tags for the features

### DIFF
--- a/nominatim/logic/tools.py
+++ b/nominatim/logic/tools.py
@@ -71,7 +71,6 @@ def osmSearchJson(params, options, options2):
                 "limit",
                 "exclude_place_ids",
                 "addressdetails",
-                "exclude_place_ids",
                 "bounded",
                 "routewidth",
                 "osm_type",

--- a/nominatim/logic/tools.py
+++ b/nominatim/logic/tools.py
@@ -85,6 +85,8 @@ def osmSearchJson(params, options, options2):
 
     params["polygon_text"] = "1"
     params["format"] = "json"
+    params["extratags"] = "1"
+    params["addressdetails"] = "1"
 
     try:
         locale = QSettings().value("locale/userLocale")
@@ -137,3 +139,23 @@ def osmSearch(canvas, txt):
         pass
 
     return None
+
+
+def dict_to_hstore_string(d):
+    """Returns an hstore string representation of the dictionary.
+
+    Note: The dictionary must be flat or the resulting hstore string
+          might be erroneous.
+
+    Args:
+        d (dict): A flat dictionary
+
+    Returns:
+        str: A hstore string representation of the dict
+    """
+
+    hstore_strings = []
+    for key, value in d.items():
+        hstore_string = f'"{key}"=>"{value}"'
+        hstore_strings.append(hstore_string)
+    return ",".join(hstore_strings)

--- a/nominatim/nominatim.py
+++ b/nominatim/nominatim.py
@@ -22,7 +22,7 @@ import os
 from qgis.PyQt.QtCore import QCoreApplication, QFileInfo, Qt, QSettings, QTranslator
 from qgis.PyQt.QtWidgets import QAction, QApplication
 from qgis.utils import showPluginHelp
-from .ui.nominatim_dlg import nominatim_dlg
+from .ui.nominatimdialog import NominatimDialog
 from .ui.nominatim_conf_dlg import nominatim_conf_dlg
 
 # from .osmLocatorFilter import OsmLocatorFilter
@@ -72,7 +72,7 @@ class Nominatim:
         try:
             self.nominatim_dlg
         except:
-            self.nominatim_dlg = nominatim_dlg(self.iface.mainWindow(), self)
+            self.nominatim_dlg = NominatimDialog(self.iface.mainWindow(), self)
             self.nominatim_dlg.visibilityChanged.connect(self.dockVisibilityChanged)
             self.nominatim_dlg.dockLocationChanged.connect(self.dockLocationChanged)
 

--- a/nominatim/ui/nominatim_dlg.py
+++ b/nominatim/ui/nominatim_dlg.py
@@ -130,7 +130,7 @@ class nominatim_dlg(QDockWidget, FORM_CLASS):
             self.doMask(item)
 
     def populateRow(self, item, idx):
-        id = item["place_id"]
+        osm_id = item.get("osm_id")
         name = item["display_name"]
 
         try:
@@ -160,7 +160,7 @@ class nominatim_dlg(QDockWidget, FORM_CLASS):
             poFD = ogr.FeatureDefn("Point")
             poFD.SetGeomType(ogr.wkbPoint)
 
-            oFLD = ogr.FieldDefn("id", ogr.OFTString)
+            oFLD = ogr.FieldDefn("osm_id", ogr.OFTInteger64)
             poFD.AddFieldDefn(oFLD)
             oFLD = ogr.FieldDefn("name", ogr.OFTString)
             poFD.AddFieldDefn(oFLD)
@@ -175,7 +175,7 @@ class nominatim_dlg(QDockWidget, FORM_CLASS):
                 poFD = ogr.FeatureDefn("Rectangle")
                 poFD.SetGeomType(ogr.wkbPolygon)
 
-                oFLD = ogr.FieldDefn("id", ogr.OFTString)
+                oFLD = ogr.FieldDefn("osm_id", ogr.OFTInteger64)
                 poFD.AddFieldDefn(oFLD)
                 oFLD = ogr.FieldDefn("name", ogr.OFTString)
                 poFD.AddFieldDefn(oFLD)
@@ -194,7 +194,7 @@ class nominatim_dlg(QDockWidget, FORM_CLASS):
                 poFD = ogr.FeatureDefn("Point")
                 poFD.SetGeomType(ogr.wkbPoint)
 
-                oFLD = ogr.FieldDefn("id", ogr.OFTString)
+                oFLD = ogr.FieldDefn("osm_id", ogr.OFTInteger64)
                 poFD.AddFieldDefn(oFLD)
                 oFLD = ogr.FieldDefn("name", ogr.OFTString)
                 poFD.AddFieldDefn(oFLD)
@@ -205,8 +205,8 @@ class nominatim_dlg(QDockWidget, FORM_CLASS):
 
         ogrFeature.SetGeometry(ogrGeom)
         ogrFeature.SetFID(int(idx + 1))
-        ogrFeature.SetField(str("id"), str(id))
         ogrFeature.SetField(str("name"), name)
+        ogrFeature.SetField("osm_id", osm_id)
 
         item = QTableWidgetItem(name)
         item.setFlags(Qt.ItemIsSelectable | Qt.ItemIsEnabled)
@@ -384,13 +384,13 @@ class nominatim_dlg(QDockWidget, FORM_CLASS):
         self.transform(geom)
 
         fields = QgsFields()
-        fields.append(QgsField("id", QVariant.String))
+        fields.append(QgsField("osm_id", QVariant.LongLong))
         fields.append(QgsField("name", QVariant.String))
         fet = QgsFeature()
         fet.initAttributes(2)
         fet.setFields(fields)
         fet.setGeometry(geom)
-        fet.setAttribute("id", (ogrFeature.GetFieldAsString("id")))
+        fet.setAttribute("osm_id", (ogrFeature.GetFieldAsInteger64("osm_id")))
         fet.setAttribute("name", (ogrFeature.GetFieldAsString("name")))
 
         vl = None
@@ -403,7 +403,7 @@ class nominatim_dlg(QDockWidget, FORM_CLASS):
                 if vl:
                     self.singleLayerId[geom.type()] = vl.id()
         else:
-            layerName = "OSM " + ogrFeature.GetFieldAsString("id")
+            layerName = "OSM " + ogrFeature.GetFieldAsString("osm_id")
             vl = self.addNewLayer(layerName, geom.type(), fields)
 
         if vl is not None:
@@ -429,7 +429,7 @@ class nominatim_dlg(QDockWidget, FORM_CLASS):
         mapcrs = self.plugin.canvas.mapSettings().destinationCrs()
 
         ogrFeature = item.data(Qt.UserRole)
-        layerName = "OSM " + ogrFeature.GetFieldAsString("id")
+        layerName = "OSM " + ogrFeature.GetFieldAsString("osm_id")
         geom = QgsGeometry.fromWkt(ogrFeature.GetGeometryRef().ExportToWkt())
         self.transform(geom)
 

--- a/nominatim/ui/nominatim_dlg.py
+++ b/nominatim/ui/nominatim_dlg.py
@@ -143,15 +143,8 @@ class nominatim_dlg(QDockWidget, FORM_CLASS):
         except:
             typeName = ""
 
-        try:
-            wkt = item["geotext"]
-        except:
-            wkt = None
-
-        try:
-            osm_type = item["osm_type"]
-        except:
-            osm_type = None
+        wkt = item.get("geotext")
+        osm_type = item.get("osm_type")
 
         if osm_type == "node":
             lat = item["lat"]

--- a/nominatim/ui/nominatim_dlg.py
+++ b/nominatim/ui/nominatim_dlg.py
@@ -153,7 +153,6 @@ class nominatim_dlg(QDockWidget, FORM_CLASS):
         except:
             osm_type = None
 
-        bbox = {}
         if osm_type == "node":
             lat = item["lat"]
             lng = item["lon"]

--- a/nominatim/ui/nominatimdialog.py
+++ b/nominatim/ui/nominatimdialog.py
@@ -39,7 +39,7 @@ from nominatim.logic import tools
 FORM_CLASS, _ = uic.loadUiType(DIR_PLUGIN_ROOT / "ui/dockwidget.ui")
 
 
-class nominatim_dlg(QDockWidget, FORM_CLASS):
+class NominatimDialog(QDockWidget, FORM_CLASS):
 
     """
     Gestion de l'évènement "leave", afin d'effacer l'objet sélectionné en sortie du dock
@@ -171,7 +171,7 @@ class nominatim_dlg(QDockWidget, FORM_CLASS):
 
             poFD = ogr.FeatureDefn("Rectangle")
             poFD.SetGeomType(ogr.wkbPolygon)
-            nominatim_dlg.add_fields(poFD)
+            NominatimDialog.add_fields(poFD)
 
             ogrFeature = ogr.Feature(poFD)
             if wkt is None:
@@ -187,7 +187,7 @@ class nominatim_dlg(QDockWidget, FORM_CLASS):
 
             poFD = ogr.FeatureDefn("Point")
             poFD.SetGeomType(ogr.wkbPoint)
-            nominatim_dlg.add_fields(poFD)
+            NominatimDialog.add_fields(poFD)
 
             ogrFeature = ogr.Feature(poFD)
             wkt = "POINT({} {})".format(lng, lat)


### PR DESCRIPTION
The ID stored for the objects is the item's `place_id` which is an internal detail of each Nominatim service. For the user it would probably be much more convenient to get the object's OSM-ID.

I also added more tags to the features so the plugin now basically allows one to download OSM features with all their information. Users can easily access them using QGIS' `hstore_to_map` expression function.

And since I was at it, I also did some clean ups ;)

Fixes https://github.com/xcaeag/Nominatim-Qgis-Plugin/issues/13

Before:
![grafik](https://user-images.githubusercontent.com/7661092/119121086-4e9ae200-ba2d-11eb-814c-b402be411188.png)


After:
![grafik](https://user-images.githubusercontent.com/7661092/119120178-442c1880-ba2c-11eb-9c48-833303454fe2.png)
